### PR TITLE
Compile generic overload 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: csharp
 sudo: false  # use the new container-based Travis infrastructure 
 
 script: 
-  - ./build.sh All
+  - ./build.sh GenerateDocs

--- a/build.fsx
+++ b/build.fsx
@@ -224,8 +224,8 @@ Target "GenerateHelp" (fun _ ->
     Rename "docs/content/release-notes.md" "docs/content/RELEASE_NOTES.md"
 
     DeleteFile "docs/content/license.md"
-    CopyFile "docs/content/" "LICENSE.txt"
-    Rename "docs/content/license.md" "docs/content/LICENSE.txt"
+    CopyFile "docs/content/" "License.txt"
+    Rename "docs/content/license.md" "docs/content/License.txt"
 
     generateHelp true
 )
@@ -236,8 +236,8 @@ Target "GenerateHelpDebug" (fun _ ->
     Rename "docs/content/release-notes.md" "docs/content/RELEASE_NOTES.md"
 
     DeleteFile "docs/content/license.md"
-    CopyFile "docs/content/" "LICENSE.txt"
-    Rename "docs/content/license.md" "docs/content/LICENSE.txt"
+    CopyFile "docs/content/" "License.txt"
+    Rename "docs/content/license.md" "docs/content/License.txt"
 
     generateHelp' true true
 )

--- a/src/FSCL.Compiler.Core/KernelInfo.fs
+++ b/src/FSCL.Compiler.Core/KernelInfo.fs
@@ -106,7 +106,10 @@ module QuotationComparison =
     
     let ComputeHashCode(e:Expr) =
         hashC Set.empty e
-         
+
+/// <summary>
+/// Encapsulates information about the current thread
+/// </summary>
 type WorkItemInfo = 
     interface
         abstract member GlobalID: int -> int

--- a/src/FSCL.Compiler/Compiler.fs
+++ b/src/FSCL.Compiler/Compiler.fs
@@ -56,14 +56,14 @@ type Compiler =
     static member DefaultConfigurationComponentsRoot = Path.Combine(Compiler.DefaultConfigurationRoot, Compiler.DefaultConfigurationComponentsFolder)
 
     static member private defComponentsAssemply = 
-        [| typeof<FunctionPreprocessingStep>; 
-           typeof<FunctionTransformationStep>; 
-           typeof<FunctionCodegenStep>; 
-           typeof<ModuleParsingStep>; 
-           typeof<ModulePreprocessingStep>; 
-           typeof<ModuleCodegenStep>;
-           typeof<FunctionPostprocessingStep>;
-           typeof<AcceleratedArrayParser>;
+        [| typeof<FunctionPreprocessingStep> 
+           typeof<FunctionTransformationStep> 
+           typeof<FunctionCodegenStep> 
+           typeof<ModuleParsingStep> 
+           typeof<ModulePreprocessingStep> 
+           typeof<ModuleCodegenStep>
+           typeof<FunctionPostprocessingStep>
+           typeof<AcceleratedArrayParser>
            typeof<DefaultTypeHandler> |]
     
     val mutable cache: KernelCache 
@@ -82,16 +82,16 @@ type Compiler =
     ///In addition of the 0 or more components found, the native components are always loaded (if no configuration file is found in the first step)
     ///</remarks>
     ///
-    new(entryCreator) as this = 
-        { inherit Pipeline(Compiler.DefaultConfigurationRoot, Compiler.DefaultConfigurationComponentsFolder, Compiler.defComponentsAssemply)
+    new (entryCreator: IKernelModule -> KernelCacheEntry) as this = 
+        { inherit Pipeline (Compiler.DefaultConfigurationRoot, Compiler.DefaultConfigurationComponentsFolder, Compiler.defComponentsAssemply)
           cache = null
           cacheEntryCreator = entryCreator
         }
         then
-            this.cache <- new KernelCache(this.IsInvariantToMetaCollection, entryCreator)
-    new() = 
-        new Compiler(fun m -> new KernelCacheEntry(m))
-    
+            this.cache <- KernelCache(this.IsInvariantToMetaCollection, entryCreator)
+    new () = 
+        Compiler (fun m -> KernelCacheEntry m)
+
     ///
     ///<summary>
     ///The constructor to instantiate a compiler with a file-based configuration
@@ -101,15 +101,15 @@ type Compiler =
     ///An instance of the compiler configured with the input file
     ///</returns>
     ///
-    new(file: string, entryCreator) as this = 
+    new (file: string, entryCreator) as this = 
         { inherit Pipeline(Compiler.DefaultConfigurationRoot, Compiler.DefaultConfigurationComponentsFolder, Compiler.defComponentsAssemply, file)
           cache = null
           cacheEntryCreator = entryCreator
         }
         then
-            this.cache <- new KernelCache(this.IsInvariantToMetaCollection, entryCreator)
+            this.cache <- KernelCache(this.IsInvariantToMetaCollection, entryCreator)
     new(file: string) = 
-        new Compiler(file, fun m -> new KernelCacheEntry(m))
+        Compiler (file, fun m -> KernelCacheEntry m)
     ///
     ///<summary>
     ///The constructor to instantiate a compiler with an object-based configuration
@@ -119,22 +119,25 @@ type Compiler =
     ///An instance of the compiler configured with the input configuration object
     ///</returns>
     ///
-    new(conf: PipelineConfiguration, entryCreator) as this =
+    new (conf: PipelineConfiguration, entryCreator) as this =
         { inherit Pipeline(Compiler.DefaultConfigurationRoot, Compiler.DefaultConfigurationComponentsFolder, Compiler.defComponentsAssemply, conf)
           cache = null
           cacheEntryCreator = entryCreator
         }
         then
-            this.cache <- new KernelCache(this.IsInvariantToMetaCollection, entryCreator)
-    new(conf: PipelineConfiguration) =
-        new Compiler(conf, fun m -> new KernelCacheEntry(m))
+            this.cache <- KernelCache(this.IsInvariantToMetaCollection, entryCreator)
+    new (conf: PipelineConfiguration) =
+        Compiler(conf, fun m -> KernelCacheEntry m)
         
     member this.Compile(input, 
                         opts:Map<string,obj>) =                        
-        this.Run((box input, this.cache), opts)
+        this.Run ((box input, this.cache), opts)
                 
-    member this.Compile(input) =
-        this.Compile(input, Map.empty)
+    member this.Compile input =
+        this.Compile (input, Map.empty)
+
+    member this.Compile<'T> input =
+        this.Compile (input, Map.empty) :?> 'T
 
     member this.CacheEntryCreator 
         with get() =

--- a/src/FSCL.Compiler/GraphUtil.fs
+++ b/src/FSCL.Compiler/GraphUtil.fs
@@ -10,9 +10,9 @@ module GraphUtil =
         val mutable sorted: (('K * 'T) list option) option
     
         new () = {
-            internalData = Dictionary<'K, 'T>()
-            internalOutgoing = Dictionary<'K, List<'K>>()
-            internalIngoing = Dictionary<'K, List<'K>>()
+            internalData = Dictionary<'K, 'T> ()
+            internalOutgoing = Dictionary<'K, List<'K>> ()
+            internalIngoing = Dictionary<'K, List<'K>> ()
             sorted = None
         }
     
@@ -24,14 +24,14 @@ module GraphUtil =
         }
     
         member this.Nodes
-            with get() =
+            with get () =
                 seq {
                     for item in this.internalOutgoing do
                         yield item.Key
                 }
 
         member this.StartNodes 
-            with get() =
+            with get () =
                 seq {
                     for item in this.internalIngoing do
                         if item.Value.Count = 0 then
@@ -39,85 +39,85 @@ module GraphUtil =
                 }
             
         member this.NodeCount 
-            with get() =
+            with get () =
                 this.internalData.Count
             
         member this.EdgeCount 
-            with get() =
+            with get () =
                 let mutable c = 0
                 for item in this.internalOutgoing do
                     c <- c + item.Value.Count
                 c
             
         member this.Add(key:'K, value: 'T) =
-            if this.internalData.ContainsKey(key) then
+            if this.internalData.ContainsKey key then
                 false
             else
-                this.internalData.Add(key, value)
-                this.internalOutgoing.Add(key, new List<'K>())
-                this.internalIngoing.Add(key, new List<'K>())
+                this.internalData.Add (key, value)
+                this.internalOutgoing.Add (key, List<'K>())
+                this.internalIngoing.Add (key, List<'K>())
                 this.sorted <- None
                 true
 
-        member this.Get(id) =
-            if this.internalData.ContainsKey(id) then
-                Some(this.internalData.[id])
+        member this.Get id =
+            if this.internalData.ContainsKey id then
+                Some this.internalData.[id]
             else
                 None
             
-        member this.Outgoing(id) =
-            if this.internalOutgoing.ContainsKey(id) then
-                Some(this.internalOutgoing.[id])
+        member this.Outgoing id =
+            if this.internalOutgoing.ContainsKey id then
+                Some this.internalOutgoing.[id]
             else
                 None
             
-        member this.Ingoing(id) =
-            if this.internalIngoing.ContainsKey(id) then
-                Some(this.internalIngoing.[id])
+        member this.Ingoing id =
+            if this.internalIngoing.ContainsKey id then
+                Some this.internalIngoing.[id]
             else
                 None
 
-        member this.Connect(f: 'K, s: 'K) =
-            if not (this.internalOutgoing.[f].Contains(s)) then
-                this.internalOutgoing.[f].Add(s)
+        member this.Connect (f: 'K, s: 'K) =
+            if not (this.internalOutgoing.[f].Contains s) then
+                this.internalOutgoing.[f].Add s
                 this.sorted <- None
-            if not (this.internalIngoing.[s].Contains(f)) then
-                this.internalIngoing.[s].Add(f)
+            if not (this.internalIngoing.[s].Contains f) then
+                this.internalIngoing.[s].Add f
                 this.sorted <- None
             
-        member this.Disconnect(f: 'K, s: 'K) =
-            if (this.internalOutgoing.[f].Contains(s)) then
-                this.internalOutgoing.[f].Remove(s) |> ignore
+        member this.Disconnect (f: 'K, s: 'K) =
+            if  this.internalOutgoing.[f].Contains s then
+                this.internalOutgoing.[f].Remove s |> ignore
                 this.sorted <- None
-            if (this.internalIngoing.[s].Contains(f)) then
-                this.internalIngoing.[s].Remove(f) |> ignore
+            if  this.internalIngoing.[s].Contains f then
+                this.internalIngoing.[s].Remove f |> ignore
                 this.sorted <- None
             
         member this.Sorted 
-            with get() =
+            with get () =
                 if this.sorted.IsSome then
                     this.sorted.Value
                 else
-                    let graph = new Graph<'T,'K>(this.internalData, this.internalIngoing, this.internalOutgoing)
+                    let graph = Graph<'T,'K> (this.internalData, this.internalIngoing, this.internalOutgoing)
 
-                    let endNodes = new List<'K>()
-                    let startNodes = new List<'K>()
+                    let endNodes = List<'K> ()
+                    let startNodes = List<'K> ()
                     for item in graph.StartNodes do
-                        startNodes.Add(item)
+                        startNodes.Add item
 
                     // Process
                     while startNodes.Count > 0 do
                         let node = startNodes.[0]
-                        startNodes.RemoveAt(0)
-                        endNodes.Add(node)
+                        startNodes.RemoveAt 0
+                        endNodes.Add node
                         while(graph.Outgoing(node).Value.Count > 0) do
                             let target = graph.Outgoing(node).Value.[0]
-                            graph.Disconnect(node, target)
+                            graph.Disconnect (node, target)
                             if graph.Ingoing(target).Value.Count = 0 then
-                                startNodes.Add(target)
+                                startNodes.Add target
                     // Return
                     if graph.EdgeCount > 0 then
-                        this.sorted <- Some(None)
+                        this.sorted <- Some None
                     else
                         this.sorted <- Some(Some(List.ofSeq(seq { for item in endNodes do yield (item, graph.Get(item).Value) })))
                     this.sorted.Value

--- a/src/FSCL.Compiler/Pipeline.fs
+++ b/src/FSCL.Compiler/Pipeline.fs
@@ -33,17 +33,16 @@ type Pipeline =
     ///In addition of the 0 or more components found, the native components are always loaded (if no configuration file is found in the first step)
     ///</remarks>
     ///
-    new(confRoot, compRoot, assemblies) as this = {
-                                                    steps = [||]
-                                                    usedMetadata = null
-                                                    configurationManager = new PipelineConfigurationManager(assemblies, confRoot, compRoot)
-                                                    configuration = null 
-                                                  }   
-                                                    then
-                                                        this.configuration <- this.configurationManager.DefaultConfiguration()
-                                                        let s, m = this.configurationManager.Build(this.configuration)
-                                                        this.steps <- s
-                                                        this.usedMetadata <- new Dictionary<Type, MetadataComparer list>(m)
+    new (confRoot, compRoot, assemblies) as this = 
+        {   steps = [||]
+            usedMetadata = null
+            configurationManager = PipelineConfigurationManager (assemblies, confRoot, compRoot)
+            configuration = null 
+        } then
+            this.configuration <- this.configurationManager.DefaultConfiguration ()
+            let s, m = this.configurationManager.Build this.configuration
+            this.steps <- s
+            this.usedMetadata <- Dictionary<Type, MetadataComparer list> m
     
     ///
     ///<summary>
@@ -54,17 +53,17 @@ type Pipeline =
     ///An instance of the compiler configured with the input file
     ///</returns>
     ///
-    new(confRoot, compRoot, assemblies, file:string) as this = {                                                                    
-                                                                 steps = [||]
-                                                                 usedMetadata = null
-                                                                 configurationManager = new PipelineConfigurationManager(assemblies, confRoot, compRoot)
-                                                                 configuration = null 
-                                                               }   
-                                                                then
-                                                                    this.configuration <- this.configurationManager.LoadConfiguration(file)
-                                                                    let s,m = this.configurationManager.Build(this.configuration)
-                                                                    this.steps <- s
-                                                                    this.usedMetadata <- new Dictionary<Type, MetadataComparer list>(m)
+    new (confRoot, compRoot, assemblies, file:string) as this = 
+        {   steps = [||]
+            usedMetadata = null
+            configurationManager = PipelineConfigurationManager (assemblies, confRoot, compRoot)
+            configuration = null 
+        }   
+        then
+            this.configuration <- this.configurationManager.LoadConfiguration file
+            let s,m = this.configurationManager.Build this.configuration
+            this.steps <- s
+            this.usedMetadata <- Dictionary<Type, MetadataComparer list> m
     ///
     ///<summary>
     ///The constructor to instantiate a compiler with an object-based configuration
@@ -74,34 +73,29 @@ type Pipeline =
     ///An instance of the compiler configured with the input configuration object
     ///</returns>
     ///
-    new(confRoot, compRoot, assemblies, conf: PipelineConfiguration) as this = { 
-                                                                                 steps = [||]
-                                                                                 usedMetadata = null
-                                                                                 configurationManager = new PipelineConfigurationManager(assemblies, confRoot, compRoot)
-                                                                                 configuration = conf 
-                                                                               }   
-                                                                               then
-                                                                                   let s, m = this.configurationManager.Build(this.configuration)
-                                                                                   this.steps <- s
-                                                                                   this.usedMetadata <- new Dictionary<Type, MetadataComparer list>(m)
+    new (confRoot, compRoot, assemblies, conf: PipelineConfiguration) as this = 
+        {   steps = [||]
+            usedMetadata = null
+            configurationManager = PipelineConfigurationManager (assemblies, confRoot, compRoot)
+            configuration = conf 
+        } then
+            let s, m = this.configurationManager.Build this.configuration
+            this.steps <- s
+            this.usedMetadata <- Dictionary<Type, MetadataComparer list> m
     
     ///
     ///<summary>
     /// The compiler configuration
     ///</summary>
     ///                                                
-    member this.Configuration 
-        with get() =
-            this.configuration
+    member this.Configuration with get () = this.configuration
 
     ///
     ///<summary>
     /// The set of metadata affecting compilation result
     ///</summary>
     ///                                                
-    member this.UsedMetadata 
-        with get() =
-            this.usedMetadata
+    member this.UsedMetadata with get () = this.usedMetadata
             
 
     ///
@@ -109,66 +103,59 @@ type Pipeline =
     /// The steps count
     ///</summary>
     ///                                                
-    member this.StepsCount 
-        with get() =
-            this.steps.Length
+    member this.StepsCount with get () = this.steps.Length
             
     ///
     ///<summary>
     /// The set of metadata affecting compilation result
     ///</summary>
     ///                                                
-    member private this.IsInvariantToKernelMeta(meta1: IKernelMetaCollection, meta2: IKernelMetaCollection) =
+    member private this.IsInvariantToKernelMeta (meta1: IKernelMetaCollection, meta2: IKernelMetaCollection) =
         // Check all the meta types effectively used
-        let firstMetaNotInvariant = this.UsedMetadata |>
-                                    Seq.tryFind(fun (metaItem: KeyValuePair<Type, MetadataComparer list>) -> 
-                                        if typeof<KernelMetadataAttribute>.IsAssignableFrom(metaItem.Key) then
-                                            // Check if some steps or processors use this meta
-                                            let item1 = meta1.Get(metaItem.Key)
-                                            let item2 = meta2.Get(metaItem.Key)
-                                            // Now compare the two values of meta against all the comparers
-                                            let firstFalseComparer = metaItem.Value |> 
-                                                                     List.tryFind(fun(comp: MetadataComparer) ->
-                                                                                    not (comp.MetaEquals(item1, item2)))
-                                            firstFalseComparer.IsSome
-                                        else
-                                            false)
+        let firstMetaNotInvariant = 
+            this.UsedMetadata 
+            |> Seq.tryFind (fun (metaItem: KeyValuePair<Type, MetadataComparer list>) -> 
+                if not (typeof<KernelMetadataAttribute>.IsAssignableFrom metaItem.Key) then false else
+                // Check if some steps or processors use this meta
+                let item1 = meta1.Get metaItem.Key
+                let item2 = meta2.Get metaItem.Key
+                // Now compare the two values of meta against all the comparers
+                let firstFalseComparer = 
+                    metaItem.Value 
+                    |> List.tryFind (fun(comp: MetadataComparer) -> not (comp.MetaEquals (item1, item2)))
+                firstFalseComparer.IsSome
+            )
         firstMetaNotInvariant.IsNone
                           
-    member private this.IsInvariantToParamMeta(meta1: IParamMetaCollection, meta2: IParamMetaCollection) =
+    member private this.IsInvariantToParamMeta (meta1: IParamMetaCollection, meta2: IParamMetaCollection) =
         // Check all the meta types effectively used
-        let firstMetaNotInvariant = this.UsedMetadata |>
-                                    Seq.tryFind(fun (metaItem: KeyValuePair<Type, MetadataComparer list>) -> 
-                                        if typeof<ParameterMetadataAttribute>.IsAssignableFrom(metaItem.Key) then
-                                            // Check if some steps or processors use this meta
-                                            let item1 = meta1.Get(metaItem.Key)
-                                            let item2 = meta2.Get(metaItem.Key)
-                                            // Now compare the two values of meta against all the comparers
-                                            let firstFalseComparer = metaItem.Value |> 
-                                                                     List.tryFind(fun(comp: MetadataComparer) ->
-                                                                                    not (comp.MetaEquals(item1, item2)))
-                                            firstFalseComparer.IsSome
-                                        else
-                                            false)
-
+        let firstMetaNotInvariant = 
+            this.UsedMetadata 
+            |> Seq.tryFind (fun (metaItem: KeyValuePair<Type, MetadataComparer list>) -> 
+                if not (typeof<ParameterMetadataAttribute>.IsAssignableFrom metaItem.Key) then false else
+                // Check if some steps or processors use this meta
+                let item1 = meta1.Get metaItem.Key
+                let item2 = meta2.Get metaItem.Key
+                // Now compare the two values of meta against all the comparers
+                let firstFalseComparer = 
+                    metaItem.Value 
+                    |> List.tryFind (fun (comp: MetadataComparer) -> not (comp.MetaEquals (item1, item2)))
+                firstFalseComparer.IsSome
+            )
         firstMetaNotInvariant.IsNone
         
-    member this.IsInvariantToMetaCollection(meta1: ReadOnlyMetaCollection, meta2: ReadOnlyMetaCollection) =
+    member this.IsInvariantToMetaCollection (meta1: ReadOnlyMetaCollection, meta2: ReadOnlyMetaCollection) =
         // Check all the meta types effectively used
-        if not (this.IsInvariantToKernelMeta(meta1.KernelMeta, meta2.KernelMeta)) then
-            false
-        else if not (this.IsInvariantToParamMeta(meta1.ReturnMeta, meta2.ReturnMeta)) then
-            false
-        else if meta1.ParamMeta.Count <> meta2.ParamMeta.Count then
-            false
+        if not (this.IsInvariantToKernelMeta (meta1.KernelMeta, meta2.KernelMeta)) then false
+        elif not (this.IsInvariantToParamMeta (meta1.ReturnMeta, meta2.ReturnMeta)) then false
+        elif meta1.ParamMeta.Count <> meta2.ParamMeta.Count then false
         else 
             let mutable found = false
             let mutable i = 0
             while (not found && i < meta1.ParamMeta.Count) do
-                if not (this.IsInvariantToParamMeta(meta1.ParamMeta.[i], meta2.ParamMeta.[i])) then
-                    found <- true
-                else
-                    i <- i + 1
+                if not (this.IsInvariantToParamMeta (meta1.ParamMeta.[i], meta2.ParamMeta.[i])) 
+                then found <- true
+                else i <- i + 1
             not found
 
     ///
@@ -176,19 +163,18 @@ type Pipeline =
     ///The method to be invoke to compile a managed kernel
     ///</summary>
     ///  
-    member this.Run(input, opts: Map<string, obj>) =
+    member this.Run (input, opts: Map<string, obj>) =
         let mutable state = input
         let mutable stopCompilation = false
         let mutable i = 0
-        while not(stopCompilation) && i < this.steps.Length do
-            match this.steps.[i].Execute(state, opts) with
-            | StopCompilation(r) ->
+        while not stopCompilation && i < this.steps.Length do
+            match this.steps.[i].Execute (state, opts) with
+            | StopCompilation r ->
                 state <- r
                 stopCompilation <- true
-            | ContinueCompilation(o) ->
+            | ContinueCompilation o ->
                 state <- o
                 i <- i + 1
         state
         
-    member this.Run(input) =
-        this.Run(input, Map.empty)
+    member this.Run input = this.Run (input, Map.empty)

--- a/tests/FSCL.Compiler.Tests/AcceleratedCollectionTest.fs
+++ b/tests/FSCL.Compiler.Tests/AcceleratedCollectionTest.fs
@@ -26,7 +26,7 @@ let RecordSum(a: MyRecord) (b: MyRecord) =
 [<Test>]
 let ``Can compile array.map2 collection function`` () =
     let compiler, a, b, _, _ = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ Array.map2 FloatSum a b @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ Array.map2 FloatSum a b @>)
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual((result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize, None)
@@ -38,7 +38,7 @@ let ``Can compile array.map2 collection function`` () =
 [<Test>]
 let ``Can compile array.map2 collection function with lambda`` () =
     let compiler, a, b, _, _ = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ Array.map2 (fun e1 e2 -> e1 + e2) a b @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ Array.map2 (fun e1 e2 -> e1 + e2) a b @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual(None, (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize)
@@ -50,7 +50,7 @@ let ``Can compile array.map2 collection function with lambda`` () =
 [<Test>]
 let ``Can compile array.reduce lambda`` () =
     let compiler, a, b, _, _ = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ Array.reduce (fun e1 e2 -> e1 + e2) a @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ Array.reduce (fun e1 e2 -> e1 + e2) a @>)
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual(None, (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize)
@@ -63,7 +63,7 @@ let ``Can compile array.reduce lambda`` () =
 let ``Can compile array.reduce with record data-type`` () =
     let compiler = new Compiler()
     let a = Array.create 64 { x = 1.0f; y = 2.0f }
-    let result = compiler.Compile(<@ Array.reduce RecordSum a @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ Array.reduce RecordSum a @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual(None, (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize)
@@ -76,9 +76,9 @@ let ``Can compile array.reduce with record data-type`` () =
 let ``Can compile array.reduce lambda with record data-type`` () =
     let compiler = new Compiler()
     let a = Array.create 64 { x = 1.0f; y = 2.0f }
-    let result = compiler.Compile(<@ Array.reduce (fun el1 el2 -> 
+    let result = compiler.Compile<IKernelExpression>(<@ Array.reduce (fun el1 el2 -> 
                                                         let v = { x = el1.x + el2.x; y = el1.y + el2.y }
-                                                        v) a @>) :?> IKernelExpression
+                                                        v) a @>) 
     // No work item info should be stored
     //printf "%s\n" (result.Code.Value.ToString())
     Assert.AreEqual(None, (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize)

--- a/tests/FSCL.Compiler.Tests/CompositionTest.fs
+++ b/tests/FSCL.Compiler.Tests/CompositionTest.fs
@@ -70,6 +70,7 @@ let ``Can compile kernel composition for Newton's approximation of matrix invers
     let compiler, matA, normalization, ws = GetData()
     
     let result = 
+        compiler.Compile<IKernelExpression>
            <@ [| 0 .. 9 |] |>
                 Array.fold(fun X it ->
                                 Map2 ws 
@@ -81,7 +82,7 @@ let ``Can compile kernel composition for Newton's approximation of matrix invers
                             (matA |> 
                             MatTransp ws |> 
                             Array2D.map(fun it -> it * normalization)) 
-            @> |> compiler.Compile :?> IKernelExpression
+            @> 
     Assert.NotNull(result)
     // Check root is a composition
     Assert.IsTrue(result.KFGRoot :? KFGCollectionCompositionNode)

--- a/tests/FSCL.Compiler.Tests/DataTypeTests.fs
+++ b/tests/FSCL.Compiler.Tests/DataTypeTests.fs
@@ -73,7 +73,7 @@ let ``Can compile char vector add`` () =
     let b = Array.create 64 ((char)2)
     let c = Array.zeroCreate<char> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddChar(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddChar(a, b, c, size) @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
@@ -89,7 +89,7 @@ let ``Can compile uchar vector add`` () =
     let b = Array.create 64 ((byte)2)
     let c = Array.zeroCreate<byte> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddUchar(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddUchar(a, b, c, size) @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     Assert.AreEqual(size, wInfo)
@@ -104,7 +104,7 @@ let ``Can compile int4 vector add`` () =
     let b = Array.create 64 (int4(2))
     let c = Array.zeroCreate<int4> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddInt4(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddInt4(a, b, c, size) @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     Assert.AreEqual(size, wInfo)
@@ -121,7 +121,7 @@ let ``Can compile custom struct vector add`` () =
     let b = Array.create 64 (new MyStruct(2, 3))
     let c = Array.zeroCreate<MyStruct> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddStruct(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddStruct(a, b, c, size) @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     Assert.AreEqual(size, wInfo)
@@ -138,7 +138,7 @@ let ``Can compile custom struct with custom constructor vector add`` () =
     let b = Array.create 64 (new MyStruct(2, 3))
     let c = Array.zeroCreate<MyStruct> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddStructWithConstructor(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddStructWithConstructor(a, b, c, size) @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     Assert.AreEqual(size, wInfo)
@@ -155,7 +155,7 @@ let ``Can compile custom record vector add`` () =
     let b = Array.create 64 ({ x = 2; y = 2 })
     let c = Array.zeroCreate<MyRecord> 64
     let size = new WorkSize(64L, 64L)
-    let result = compiler.Compile(<@ VectorAddRecord(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddRecord(a, b, c, size) @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     Assert.AreEqual(size, wInfo)

--- a/tests/FSCL.Compiler.Tests/DynamicDefineTest.fs
+++ b/tests/FSCL.Compiler.Tests/DynamicDefineTest.fs
@@ -19,7 +19,7 @@ module KernelModule =
         c.[gid] <- a.[gid] + b.[gid] * DataFieldModule
         
     let Compile(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ VectorAddModule(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddModule(size, a, b, c) @>) 
             
 type KernelWrapper(data: float32) =        
     [<ConstantDefine>] 
@@ -105,28 +105,28 @@ type KernelWrapper(data: float32) =
         c.[gid] <- a.[gid] + b.[gid] * KernelModule.DataFieldModule
                         
     member this.CompileVectorAddUsingField(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingField(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingField(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingMutableField(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingMutableField(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingMutableField(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingFieldFromConstructor(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingPropertyWithGet(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingPropertyWithGet(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingPropertyWithGet(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingPropertyWithGetSet(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingPropertyWithGetFromConstructor(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) 
         
     member this.CompileVectorAddUsingStaticField(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingStaticField(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingStaticField(size, a, b, c) @>) 
                         
     member this.CompileVectorAddUsingModuleField(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddUsingModuleField(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddUsingModuleField(size, a, b, c) @>) 
         
 let GetData() =
     let compiler = new Compiler()
@@ -152,7 +152,7 @@ let ``Can compile module kernel using module field from inside and outside modul
     Assert.NotNull(insideResult)
     Assert.IsNotEmpty((insideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult, None), 10.0f)
-    let outsideResult = compiler.Compile(<@ KernelModule.VectorAddModule(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelModule.VectorAddModule(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, None), 10.0f)
@@ -172,7 +172,7 @@ let ``Can compile kernel using instance field from inside and outside instance``
     let insideResult = wrapper.CompileVectorAddUsingField(compiler, size, a, b, c)
     Assert.IsNotEmpty((insideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult, Some(wrapper)), 10.0f)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingField(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingField(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
 
@@ -197,11 +197,11 @@ let ``Can compile kernel using mutable instance field from inside and outside in
     Assert.AreEqual(FirstConstDefineValue(insideResult2, Some(wrapper)), 5.0f)
     
     wrapper.DataPropertyWithGetSet <- 10.0f    
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingMutableField(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingMutableField(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
     wrapper.DataPropertyWithGetSet <- 5.0f    
-    let outsideResult2 = compiler.Compile(<@ wrapper.VectorAddUsingMutableField(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult2 = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingMutableField(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult2, Some(wrapper)), 5.0f)
     
@@ -230,10 +230,10 @@ let ``Can compile kernel using field set from constructor from inside and outsid
     Assert.IsNotEmpty((insideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult2, Some(wrapper2)), 2.0f)
         
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
-    let outsideResult2 = compiler.Compile(<@ wrapper2.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult2 = compiler.Compile<IKernelExpression>(<@ wrapper2.VectorAddUsingFieldFromConstructor(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult2, Some(wrapper2)), 2.0f)
     
@@ -257,7 +257,7 @@ let ``Can compile kernel using getter property from inside and outside instance`
     let insideResult = wrapper.CompileVectorAddUsingPropertyWithGet(compiler, size, a, b, c)
     Assert.IsNotEmpty((insideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult, Some(wrapper)), 10.0f)        
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingPropertyWithGet(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingPropertyWithGet(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
     
@@ -280,10 +280,10 @@ let ``Can compile kernel using getter property from constructor from inside and 
     Assert.IsNotEmpty((insideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult2, Some(wrapper2)), 2.0f)
         
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
-    let outsideResult2 = compiler.Compile(<@ wrapper2.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult2 = compiler.Compile<IKernelExpression>(<@ wrapper2.VectorAddUsingPropertyWithGetFromConstructor(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult2, Some(wrapper2)), 2.0f)
     
@@ -313,11 +313,11 @@ let ``Can compile kernel using getter-setter property from inside and outside in
     Assert.AreEqual(FirstConstDefineValue(insideResult2, Some(wrapper)), 3.0f)
         
     wrapper.DataPropertyWithGetSet <- 10.0f
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
     wrapper.DataPropertyWithGetSet <- 3.0f
-    let outsideResult2 = compiler.Compile(<@ wrapper.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult2 = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingPropertyWithGetSet(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult2.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult2, Some(wrapper)), 3.0f)
     
@@ -341,7 +341,7 @@ let ``Can compile kernel using static field from inside and outside instance`` (
     let insideResult = wrapper.CompileVectorAddUsingStaticField(compiler, size, a, b, c)
     Assert.IsNotEmpty((insideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult, Some(wrapper)), 10.0f)        
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingStaticField(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingStaticField(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
     
@@ -359,7 +359,7 @@ let ``Can compile instance kernel using module field from inside and outside ins
     let insideResult = wrapper.CompileVectorAddUsingModuleField(compiler, size, a, b, c)
     Assert.IsNotEmpty((insideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(insideResult, Some(wrapper)), 10.0f)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddUsingModuleField(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddUsingModuleField(size, a, b, c) @>) 
     Assert.IsNotEmpty((outsideResult.KFGRoot :?> KFGKernelNode).Module.ConstantDefines)
     Assert.AreEqual(FirstConstDefineValue(outsideResult, Some(wrapper)), 10.0f)
     

--- a/tests/FSCL.Compiler.Tests/FunctionContextTest.fs
+++ b/tests/FSCL.Compiler.Tests/FunctionContextTest.fs
@@ -28,10 +28,10 @@ module KernelModule =
         c.[gid] <- UtilFunctionCurried a.[gid] b.[gid]
         
     let CompileVectorAddTupled(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ VectorAddWithModuleTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddWithModuleTupledFunction(size, a, b, c) @>) 
         
     let CompileVectorAddCurried(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ VectorAddWithModuleCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddWithModuleCurriedFunction(size, a, b, c) @>) 
     
 type KernelWrapper() =
     [<ReflectedDefinition>] 
@@ -119,40 +119,40 @@ type KernelWrapper() =
         c.[gid] <- KernelWrapper.UtilFunctionCurriedStatic a.[gid] b.[gid]
         
     member this.CompileVectorAddTupledField(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ VectorAddFieldTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddFieldTupledFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedField(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ VectorAddFieldCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddFieldCurriedFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddTupledFieldFromMember(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddFieldTupledFunctionFromMember(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddFieldTupledFunctionFromMember(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedFieldFromMember(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ this.VectorAddFieldCurriedFunctionFromMember(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddFieldCurriedFunctionFromMember(size, a, b, c) @>) 
                 
     member this.CompileVectorAddTupledMember(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddMemberTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddMemberTupledFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedMember(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddMemberCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddMemberCurriedFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddTupledMemberStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddStaticTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddStaticTupledFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedMemberStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddStaticCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddStaticCurriedFunction(size, a, b, c) @>) 
                 
     member this.CompileVectorAddTupledMemberStaticFromStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ KernelWrapper.VectorAddStaticTupledFunctionFromStatic(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddStaticTupledFunctionFromStatic(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedMemberStaticFromStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ KernelWrapper.VectorAddStaticCurriedFunctionFromStatic(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddStaticCurriedFunctionFromStatic(size, a, b, c) @>) 
         
     member this.CompileVectorAddTupledModule(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddModuleTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddModuleTupledFunction(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedModule(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddModuleCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddModuleCurriedFunction(size, a, b, c) @>) 
     
 let GetData() =
     let compiler = new Compiler()
@@ -170,7 +170,7 @@ let ``Can compile kernel with tupled module function from inside and outside mod
     let insideResult = KernelModule.CompileVectorAddTupled(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelModule.VectorAddWithModuleTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelModule.VectorAddWithModuleTupledFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -187,7 +187,7 @@ let ``Can compile kernel with curried module function from inside and outside mo
     let insideResult = KernelModule.CompileVectorAddCurried(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelModule.VectorAddWithModuleCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelModule.VectorAddWithModuleCurriedFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -204,7 +204,7 @@ let ``Can compile kernel with tupled module function called from instance kernel
     let insideResult = wrapper.CompileVectorAddTupledModule(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddModuleCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddModuleCurriedFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -221,7 +221,7 @@ let ``Can compile kernel with curried module function called from instance kerne
     let insideResult = wrapper.CompileVectorAddCurriedModule(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddModuleCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddModuleCurriedFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -260,7 +260,7 @@ let ``Can compile kernel with tupled instance field function called from member 
     let insideResult = wrapper.CompileVectorAddTupledFieldFromMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddFieldTupledFunctionFromMember(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddFieldTupledFunctionFromMember(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -277,7 +277,7 @@ let ``Can compile kernel with curried instance field function called from member
     let insideResult = wrapper.CompileVectorAddCurriedFieldFromMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddFieldCurriedFunctionFromMember(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddFieldCurriedFunctionFromMember(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -294,7 +294,7 @@ let ``Can compile kernel with tupled instance member function from inside and ou
     let insideResult = wrapper.CompileVectorAddTupledMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddMemberTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddMemberTupledFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -311,7 +311,7 @@ let ``Can compile kernel with curried instance member from inside and outside in
     let insideResult = wrapper.CompileVectorAddCurriedMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddMemberCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddMemberCurriedFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -328,7 +328,7 @@ let ``Can compile kernel with tupled static member function called from instance
     let insideResult = wrapper.CompileVectorAddTupledMemberStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddStaticTupledFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddStaticTupledFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -345,7 +345,7 @@ let ``Can compile kernel with curried static member function called from instanc
     let insideResult = wrapper.CompileVectorAddCurriedMemberStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddStaticCurriedFunction(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddStaticCurriedFunction(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -362,7 +362,7 @@ let ``Can compile kernel with tupled static member function called from static k
     let insideResult = wrapper.CompileVectorAddTupledMemberStaticFromStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelWrapper.VectorAddStaticTupledFunctionFromStatic(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddStaticTupledFunctionFromStatic(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -379,7 +379,7 @@ let ``Can compile kernel with curried static member function called from static 
     let insideResult = wrapper.CompileVectorAddCurriedMemberStaticFromStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelWrapper.VectorAddStaticCurriedFunctionFromStatic(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddStaticCurriedFunctionFromStatic(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
 

--- a/tests/FSCL.Compiler.Tests/KernelCompilationTests.fs
+++ b/tests/FSCL.Compiler.Tests/KernelCompilationTests.fs
@@ -73,7 +73,7 @@ let VectorAddWithNestedUtility(a: float32[], b:float32[], c:float32[], wi:WorkIt
 //[<Test>]
 let ``Can compile tupled kernel reference`` () =
     let compiler = new Compiler()
-    let result = compiler.Compile(<@ VectorAdd @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAdd @>)
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual((result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize, None)
@@ -86,7 +86,7 @@ let ``Can compile tupled kernel reference`` () =
 //[<Test>]
 let ``Can compile curried kernel reference`` () =
     let compiler = new Compiler()
-    let result = compiler.Compile(<@ VectorAddCurried @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddCurried @>)
     //printf "%s\n" (result.Code.Value.ToString())
     // No work item info should be stored
     Assert.AreEqual(None, (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize)
@@ -99,7 +99,7 @@ let ``Can compile curried kernel reference`` () =
 [<Test>]
 let ``Can compile tupled kernel call`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ VectorAdd(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAdd(a, b, c, size) @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
@@ -113,7 +113,7 @@ let ``Can compile tupled kernel call`` () =
 [<Test>]
 let ``Can compile curried kernel call`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ VectorAddCurried a b c size @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddCurried a b c size @>) 
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
     let log, success = TestUtil.TryCompileOpenCL((result.KFGRoot :?> KFGKernelNode).Module)
@@ -123,7 +123,7 @@ let ``Can compile curried kernel call`` () =
 [<Test>]
 let ``Can compile kernel with utility functions`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ VectorAddWithUtility(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddWithUtility(a, b, c, size) @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
@@ -148,7 +148,7 @@ let ``Can compile kernel with utility functions`` () =
 [<Test>]
 let ``Can compile kernel with inline and nested utility functions`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ VectorAddWithNestedUtility(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddWithNestedUtility(a, b, c, size) @>)
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
@@ -169,7 +169,7 @@ let ``Can compile kernel with inline and nested utility functions`` () =
 [<Test>]
 let ``Can compile kernel returning a parameter`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
-    let result = compiler.Compile(<@ VectorAddWithReturnParameter(a, b, c, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddWithReturnParameter(a, b, c, size) @>) 
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored
@@ -183,7 +183,7 @@ let ``Can compile kernel with reference cells`` () =
     let compiler, a, b, c, size = TestUtil.GetVectorSampleData()
     let r = ref 2.0f
 
-    let result = compiler.Compile(<@ VectorAddWithRefCell(a, b, c, r, size) @>) :?> IKernelExpression
+    let result = compiler.Compile<IKernelExpression>(<@ VectorAddWithRefCell(a, b, c, r, size) @>)
     //printf "%s\n" (result.Code.Value.ToString())
     let wInfo = (result.KFGRoot :?> KFGKernelNode).Module.Kernel.WorkSize.Value
     // Work item info should be stored

--- a/tests/FSCL.Compiler.Tests/KernelContextTest.fs
+++ b/tests/FSCL.Compiler.Tests/KernelContextTest.fs
@@ -20,10 +20,10 @@ module KernelModule =
         c.[gid] <- a.[gid] + b.[gid]
         
     let CompileVectorAddTupled(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ VectorAddTupledInModule(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddTupledInModule(size, a, b, c) @>) 
         
     let CompileVectorAddCurried(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ VectorAddCurriedInModule size a b c @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddCurriedInModule size a b c @>) 
     
 [<AbstractClass>]
 type Base() =
@@ -71,28 +71,28 @@ type KernelWrapper() =
         c.[gid] <- a.[gid] + b.[gid]
 
     member this.CompileVectorAddTupled(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ VectorAddTupled(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddTupled(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurried(compiler: Compiler, size, a, b, c) =        
-        compiler.Compile(<@ VectorAddCurried size a b c @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ VectorAddCurried size a b c @>) 
                 
     member this.CompileVectorAddTupledMember(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddTupledMember(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddTupledMember(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedMember(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddCurriedMember size a b c @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddCurriedMember size a b c @>) 
         
     member this.CompileVectorAddTupledMemberStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ KernelWrapper.VectorAddTupledMemberStatic(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddTupledMemberStatic(size, a, b, c) @>) 
         
     member this.CompileVectorAddCurriedMemberStatic(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ KernelWrapper.VectorAddCurriedMemberStatic size a b c @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddCurriedMemberStatic size a b c @>) 
                 
     member this.CompileVectorAddTupledMemberBase(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddTupledMemberBase(size, a, b, c) @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddTupledMemberBase(size, a, b, c) @>) 
 
     member this.CompileVectorAddCurriedMemberBase(compiler: Compiler, size, a, b, c) =
-        compiler.Compile(<@ this.VectorAddCurriedMemberBase size a b c @>) :?> IKernelExpression
+        compiler.Compile<IKernelExpression>(<@ this.VectorAddCurriedMemberBase size a b c @>) 
         
 [<Test>]
 let ``Can compile tupled module field kernel from inside and outside the module`` () =
@@ -100,7 +100,7 @@ let ``Can compile tupled module field kernel from inside and outside the module`
     let insideResult = KernelModule.CompileVectorAddTupled(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelModule.VectorAddTupledInModule(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelModule.VectorAddTupledInModule(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -117,7 +117,7 @@ let ``Can compile curried module field kernel from inside and outside the module
     let insideResult = KernelModule.CompileVectorAddCurried(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelModule.VectorAddCurriedInModule size a b c @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelModule.VectorAddCurriedInModule size a b c @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -155,7 +155,7 @@ let ``Can compile tupled instance member kernel from inside and outside the inst
     let insideResult = wrapper.CompileVectorAddTupledMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddTupledMember(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddTupledMember(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -173,7 +173,7 @@ let ``Can compile curried instance member kernel from inside and outside the ins
     let insideResult = wrapper.CompileVectorAddCurriedMember(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddCurriedMember size a b c @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddCurriedMember size a b c @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -191,7 +191,7 @@ let ``Can compile tupled static member kernel from inside and outside the instan
     let insideResult = wrapper.CompileVectorAddTupledMemberStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelWrapper.VectorAddTupledMemberStatic(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddTupledMemberStatic(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -209,7 +209,7 @@ let ``Can compile curried static member kernel from inside and outside the insta
     let insideResult = wrapper.CompileVectorAddCurriedMemberStatic(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ KernelWrapper.VectorAddCurriedMemberStatic size a b c @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ KernelWrapper.VectorAddCurriedMemberStatic size a b c @>) 
     Assert.NotNull(outsideResult)
     Assert.AreSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -227,7 +227,7 @@ let ``Can compile tupled inherited instance member kernel from inside and outsid
     let insideResult = wrapper.CompileVectorAddTupledMemberBase(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddTupledMemberBase(size, a, b, c) @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddTupledMemberBase(size, a, b, c) @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     
@@ -245,7 +245,7 @@ let ``Can compile curried inherited instance member kernel from inside and outsi
     let insideResult = wrapper.CompileVectorAddCurriedMemberBase(compiler, size, a, b, c)
     Assert.NotNull(insideResult)
     Assert.AreNotSame(None, (insideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
-    let outsideResult = compiler.Compile(<@ wrapper.VectorAddCurriedMemberBase size a b c @>) :?> IKernelExpression
+    let outsideResult = compiler.Compile<IKernelExpression>(<@ wrapper.VectorAddCurriedMemberBase size a b c @>) 
     Assert.NotNull(outsideResult)
     Assert.AreNotSame(None, (outsideResult.KFGRoot :?> KFGKernelNode).Module.InstanceExpr)
     


### PR DESCRIPTION
- added a generic parameter for compile so it doesn't need to be manually cast
- reformatted some code
- removed superfluous parentheses
- fixed some F# styling conventions
